### PR TITLE
New Punk Domains NFTs (v2) on Gnosis Chain

### DIFF
--- a/all.json
+++ b/all.json
@@ -352,32 +352,8 @@
     "override": true
   },
   {
-    "name": ".gnosis (deprecated)",
-    "address": "0xBDACF94dDCAB51c39c2dD50BffEe60Bb8021949a",
-    "symbol": ".GNOSIS",
-    "chainId": 100,
-    "logoURI": "https://raw.githubusercontent.com/lab10-coop/minerva-nft-list/main/images/punk-domains-logo.png",
-    "override": true
-  },
-  {
-    "name": ".xdai (deprecated)",
-    "address": "0xefbe0b46649b7a0f1e1d49cca98ad9cf6bcfb096",
-    "symbol": ".XDAI",
-    "chainId": 100,
-    "logoURI": "https://raw.githubusercontent.com/lab10-coop/minerva-nft-list/main/images/punk-domains-logo.png",
-    "override": true
-  },
-  {
-    "name": ".bright (deprecated)",
-    "address": "0x4da0a46cc54439b1dE0203d376b98D988697091d",
-    "symbol": ".BRIGHT",
-    "chainId": 100,
-    "logoURI": "https://raw.githubusercontent.com/lab10-coop/minerva-nft-list/main/images/punk-domains-logo.png",
-    "override": true
-  },
-  {
     "name": ".web3 (punk.domains)",
-    "address": "0x46Ee2d28f4b3555492296bfE1509Ea22FF47b71e",
+    "address": "0xb6Cf2874588d0fdFAf9d1b5E254ee6C49110C68B",
     "symbol": ".WEB3",
     "chainId": 137,
     "logoURI": "https://raw.githubusercontent.com/lab10-coop/minerva-nft-list/main/images/punk-domains-logo.png",
@@ -385,7 +361,7 @@
   },
   {
     "name": ".polygon (punk.domains)",
-    "address": "0xdf9559841F6ee36C6a86FE7c058bD8736E132c5f",
+    "address": "0xa450bc33d0940d25fB0961c592fb440Fa63ABE03",
     "symbol": ".POLYGON",
     "chainId": 137,
     "logoURI": "https://raw.githubusercontent.com/lab10-coop/minerva-nft-list/main/images/punk-domains-logo.png",
@@ -393,7 +369,7 @@
   },
   {
     "name": ".ape (punk.domains)",
-    "address": "0xBe3655C0e457DF3A551E5d0Ecee5D6a6E69E3E8d",
+    "address": "0x794a8390D94E32b086908D2bA9D66300aA163C62",
     "symbol": ".APE",
     "chainId": 137,
     "logoURI": "https://raw.githubusercontent.com/lab10-coop/minerva-nft-list/main/images/punk-domains-logo.png",
@@ -401,7 +377,7 @@
   },
   {
     "name": ".poly (punk.domains)",
-    "address": "0x760D82D92f3A76d961961D6607E062Ca10b1C172",
+    "address": "0x70Ac07C50131b7bb2c8Bd9466D8d2add30B7759f",
     "symbol": ".POLY",
     "chainId": 137,
     "logoURI": "https://raw.githubusercontent.com/lab10-coop/minerva-nft-list/main/images/punk-domains-logo.png",
@@ -409,16 +385,8 @@
   },
   {
     "name": ".degen (punk.domains)",
-    "address": "0x614cD3F6751ABD5a8d33C04AdE6dFeF58b521820",
+    "address": "0xC4999A3e91ef87c9EC5d8186D02B77F9A62458b9",
     "symbol": ".DEGEN",
-    "chainId": 137,
-    "logoURI": "https://raw.githubusercontent.com/lab10-coop/minerva-nft-list/main/images/punk-domains-logo.png",
-    "override": true
-  },
-  {
-    "name": ".humandao (punk.domains)",
-    "address": "0xFeB49640DF4eA8d14FfB452B53DcEE275064d77C",
-    "symbol": ".HUMANDAO",
     "chainId": 137,
     "logoURI": "https://raw.githubusercontent.com/lab10-coop/minerva-nft-list/main/images/punk-domains-logo.png",
     "override": true
@@ -447,6 +415,80 @@
     "logoURI": "https://raw.githubusercontent.com/lab10-coop/minerva-nft-list/main/images/GnosisTigers.jpg",
     "override": false
   },
+  
+  {
+    "name": ".gnosis (deprecated)",
+    "address": "0xBDACF94dDCAB51c39c2dD50BffEe60Bb8021949a",
+    "symbol": ".GNOSIS",
+    "chainId": 100,
+    "logoURI": "https://raw.githubusercontent.com/lab10-coop/minerva-nft-list/main/images/deprecated.svg",
+    "override": true
+  },
+  {
+    "name": ".xdai (deprecated)",
+    "address": "0xefbe0b46649b7a0f1e1d49cca98ad9cf6bcfb096",
+    "symbol": ".XDAI",
+    "chainId": 100,
+    "logoURI": "https://raw.githubusercontent.com/lab10-coop/minerva-nft-list/main/images/deprecated.svg",
+    "override": true
+  },
+  {
+    "name": ".bright (deprecated)",
+    "address": "0x4da0a46cc54439b1dE0203d376b98D988697091d",
+    "symbol": ".BRIGHT",
+    "chainId": 100,
+    "logoURI": "https://raw.githubusercontent.com/lab10-coop/minerva-nft-list/main/images/deprecated.svg",
+    "override": true
+  },
+  {
+    "name": ".web3 (deprecated)",
+    "address": "0x46Ee2d28f4b3555492296bfE1509Ea22FF47b71e",
+    "symbol": ".WEB3",
+    "chainId": 137,
+    "logoURI": "https://raw.githubusercontent.com/lab10-coop/minerva-nft-list/main/images/deprecated.svg",
+    "override": true
+  },
+  {
+    "name": ".polygon (deprecated)",
+    "address": "0xdf9559841F6ee36C6a86FE7c058bD8736E132c5f",
+    "symbol": ".POLYGON",
+    "chainId": 137,
+    "logoURI": "https://raw.githubusercontent.com/lab10-coop/minerva-nft-list/main/images/deprecated.svg",
+    "override": true
+  },
+  {
+    "name": ".ape (deprecated)",
+    "address": "0xBe3655C0e457DF3A551E5d0Ecee5D6a6E69E3E8d",
+    "symbol": ".APE",
+    "chainId": 137,
+    "logoURI": "https://raw.githubusercontent.com/lab10-coop/minerva-nft-list/main/images/deprecated.svg",
+    "override": true
+  },
+  {
+    "name": ".poly (deprecated)",
+    "address": "0x760D82D92f3A76d961961D6607E062Ca10b1C172",
+    "symbol": ".POLY",
+    "chainId": 137,
+    "logoURI": "https://raw.githubusercontent.com/lab10-coop/minerva-nft-list/main/images/deprecated.svg",
+    "override": true
+  },
+  {
+    "name": ".degen (deprecated)",
+    "address": "0x614cD3F6751ABD5a8d33C04AdE6dFeF58b521820",
+    "symbol": ".DEGEN",
+    "chainId": 137,
+    "logoURI": "https://raw.githubusercontent.com/lab10-coop/minerva-nft-list/main/images/deprecated.svg",
+    "override": true
+  },
+  {
+    "name": ".humandao (deprecated)",
+    "address": "0xFeB49640DF4eA8d14FfB452B53DcEE275064d77C",
+    "symbol": ".HUMANDAO",
+    "chainId": 137,
+    "logoURI": "https://raw.githubusercontent.com/lab10-coop/minerva-nft-list/main/images/deprecated.svg",
+    "override": true
+  },
+  
   {
     "name": "Placeholder",
     "address": "0x0000000000000000000000000000000000000000",

--- a/all.json
+++ b/all.json
@@ -329,7 +329,7 @@
   },
   {
     "name": ".gnosis (punk.domains)",
-    "address": "0xBDACF94dDCAB51c39c2dD50BffEe60Bb8021949a",
+    "address": "0xC3E8922657686EC63eaaa9FC1Fe06826802e7e0f",
     "symbol": ".GNOSIS",
     "chainId": 100,
     "logoURI": "https://raw.githubusercontent.com/lab10-coop/minerva-nft-list/main/images/punk-domains-logo.png",
@@ -337,7 +337,7 @@
   },
   {
     "name": ".xdai (punk.domains)",
-    "address": "0xefbe0b46649b7a0f1e1d49cca98ad9cf6bcfb096",
+    "address": "0xbca24d86e4ad1e011278faefc4ff191a731411ec",
     "symbol": ".XDAI",
     "chainId": 100,
     "logoURI": "https://raw.githubusercontent.com/lab10-coop/minerva-nft-list/main/images/punk-domains-logo.png",
@@ -345,6 +345,30 @@
   },
   {
     "name": ".bright (punk.domains)",
+    "address": "0x3490c9817c45a2a394b11a3807f58a8325235ae0",
+    "symbol": ".BRIGHT",
+    "chainId": 100,
+    "logoURI": "https://raw.githubusercontent.com/lab10-coop/minerva-nft-list/main/images/punk-domains-logo.png",
+    "override": true
+  },
+  {
+    "name": ".gnosis (deprecated)",
+    "address": "0xBDACF94dDCAB51c39c2dD50BffEe60Bb8021949a",
+    "symbol": ".GNOSIS",
+    "chainId": 100,
+    "logoURI": "https://raw.githubusercontent.com/lab10-coop/minerva-nft-list/main/images/punk-domains-logo.png",
+    "override": true
+  },
+  {
+    "name": ".xdai (deprecated)",
+    "address": "0xefbe0b46649b7a0f1e1d49cca98ad9cf6bcfb096",
+    "symbol": ".XDAI",
+    "chainId": 100,
+    "logoURI": "https://raw.githubusercontent.com/lab10-coop/minerva-nft-list/main/images/punk-domains-logo.png",
+    "override": true
+  },
+  {
+    "name": ".bright (deprecated)",
     "address": "0x4da0a46cc54439b1dE0203d376b98D988697091d",
     "symbol": ".BRIGHT",
     "chainId": 100,

--- a/images/deprecated.svg
+++ b/images/deprecated.svg
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="400"
+   height="400"
+   id="svg3026"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="Forbidden_Symbol_Transparent.svg">
+  <metadata
+     id="metadata3038">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3036" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1309"
+     inkscape:window-height="744"
+     id="namedview3034"
+     showgrid="false"
+     inkscape:zoom="1.0066432"
+     inkscape:cx="330.95341"
+     inkscape:cy="149.93709"
+     inkscape:window-x="57"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g3028"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3040"
+       originx="183.604"
+       originy="183.604" />
+  </sodipodi:namedview>
+  <g
+     id="g3028"
+     style="stroke:#d40000;stroke-width:2.23000002"
+     transform="translate(183.604,196.39599)">
+    <g
+       id="g4155">
+      <path
+         sodipodi:nodetypes="ccccc"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#d40000;fill-opacity:1;stroke:none;stroke-width:2.23000002;marker:none;enable-background:accumulate"
+         d="m -116.9899,106.24536 31.819808,31.8198 236.310532,-236.310518 -31.81982,-31.819802 z"
+         id="path3818"
+         inkscape:connector-curvature="0" />
+      <circle
+         style="fill:none;stroke-width:44.59999847"
+         id="circle3030"
+         r="171.304"
+         cy="4"
+         cx="16" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
The old Punk Domains NFTs are now deprecated and replaced with v2. All NFT holders got the new domains/NFTs, but the old ones will still show up in the wallets, that's why it makes sense to mark them as deprecated. 

@seliqui also suggested changing an image of the deprecated NFTs so that they visibly differentiate from the new ones.